### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:latest
+
+RUN apt-get -y update && \
+	apt-get -y install curl apt-transport-https gnupg && \
+	curl -s https://arkanosis.net/jroquet.pub.asc | apt-key add - && \
+	echo "deb https://apt.arkanosis.net/ software stable" | tee /etc/apt/sources.list.d/arkanosis.list && \
+	apt-get -y update && \
+	apt-get -y install bamrescue && \
+	apt-get -y clean
+
+CMD bamrescue --help


### PR DESCRIPTION
This adds a Dockerfile that builds a Docker image for `bamrescue` based on the most recent version available in the arkanosis apt repo.  

This makes it much easier to install and use the program in circumstances where the user might have access to run containerized software, but might not be able to install software system-wide.  A Docker image allows it to be run on many HPC or other hardware with Docker, Apptainer (neé Singularity), Podman, and other container hosts.  