### PR TITLE
Added procps to Dockerfile for Nextflow compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:latest
 
 RUN apt-get -y update && \
-	apt-get -y install curl apt-transport-https gnupg && \
-	curl -s https://arkanosis.net/jroquet.pub.asc | apt-key add - && \
-	echo "deb https://apt.arkanosis.net/ software stable" | tee /etc/apt/sources.list.d/arkanosis.list && \
-	apt-get -y update && \
-	apt-get -y install bamrescue && \
-	apt-get -y clean
+    apt-get -y install apt-transport-https curl gnupg procps && \
+    curl -s https://arkanosis.net/jroquet.pub.asc | apt-key add - && \
+    echo "deb https://apt.arkanosis.net/ software stable" | tee /etc/apt/sources.list.d/arkanosis.list && \
+    apt-get -y update && \
+    apt-get -y install bamrescue && \
+    apt-get -y clean
 
 CMD bamrescue --help


### PR DESCRIPTION
[Nextflow](https://nextflow.io) requires `ps` in containers for execution tracing, and that is provided by the `procps` package in Debian.

See https://www.nextflow.io/docs/latest/tracing.html#execution-report-tasks for what is needed, and I believe those are all in images built with the updated `Dockerfile`.

This request also reorders the apt-get request to alphabetical order and changes tabs to spaces. 